### PR TITLE
Specifying 'latest' in environment variables to install the latests v…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -78,7 +78,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       puppet.manifest_file  = "site.pp"
       puppet.facter = {
         "api_token" => ENV["API_TOKEN"],
-        "docker_version" => ENV["DOCKER_VERSION"] ||= "latest"
+        # If the environment variable is not set than default to current
+        # version at the time of this writing it is 1.7.1
+        # NOTE: The docker puppet indicates you can use latest to the
+        # most up to date but installation fails
+        "docker_version" => ENV["DOCKER_VERSION"] ||= "1.7.1"
       }
     end
   end


### PR DESCRIPTION
…ersion of docker causes the docker installation to fail. Defaulting to that latest version of Docker currently, 1.7.1 as a work around, so that the end user does not have to explictly specify a docker version to have a succesfully install
